### PR TITLE
Add ClamAV 1.5 APIs and bump version to 1.5.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,188 @@
+name: Build and Test
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+env:
+  CLAMAV_VERSION: 1.5.2
+
+jobs:
+  linux:
+    name: Linux (${{ matrix.mode }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        mode:
+          - pkg-config
+          - manual
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        run: rustup update stable --no-self-update && rustup default stable
+
+      - name: Install Linux build dependencies
+        shell: bash
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y pkg-config libssl-dev
+
+      - name: Install ClamAV release package
+        shell: bash
+        run: |
+          wget "https://github.com/Cisco-Talos/clamav/releases/download/clamav-${CLAMAV_VERSION}/clamav-${CLAMAV_VERSION}.linux.x86_64.deb"
+          sudo dpkg -i "clamav-${CLAMAV_VERSION}.linux.x86_64.deb"
+
+      - name: Build and test with pkg-config
+        if: matrix.mode == 'pkg-config'
+        shell: bash
+        env:
+          LD_LIBRARY_PATH: /usr/local/lib
+        run: cargo test -- --test-threads=1
+
+      - name: Build and test with manual library paths
+        if: matrix.mode == 'manual'
+        shell: bash
+        env:
+          CLAMAV_LIBRARY: /usr/local/lib/libclamav.so
+          CLAMAV_INCLUDE: /usr/local/include
+          OPENSSL_INCLUDE: /usr/include
+          LD_LIBRARY_PATH: /usr/local/lib
+        run: cargo test -- --test-threads=1
+
+  macos:
+    name: macOS
+    runs-on: macos-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        run: rustup update stable --no-self-update && rustup default stable
+
+      - name: Install Homebrew dependencies
+        shell: bash
+        run: |
+          brew update
+          brew install clamav openssl@3 pkg-config
+
+      - name: Build and test
+        shell: bash
+        env:
+          OPENSSL_INCLUDE: ${{ runner.temp }}/openssl-include
+          PKG_CONFIG_PATH: /opt/homebrew/lib/pkgconfig:/opt/homebrew/opt/clamav/lib/pkgconfig:/opt/homebrew/opt/openssl@3/lib/pkgconfig:/usr/local/lib/pkgconfig:/usr/local/opt/clamav/lib/pkgconfig:/usr/local/opt/openssl@3/lib/pkgconfig
+          DYLD_LIBRARY_PATH: /opt/homebrew/lib:/opt/homebrew/opt/clamav/lib:/opt/homebrew/opt/openssl@3/lib:/usr/local/lib:/usr/local/opt/clamav/lib:/usr/local/opt/openssl@3/lib
+        run: |
+          OPENSSL_PREFIX="$(brew --prefix openssl@3)"
+          mkdir -p "$OPENSSL_INCLUDE"
+          rm -rf "$OPENSSL_INCLUDE"
+          ln -s "$OPENSSL_PREFIX/include" "$OPENSSL_INCLUDE"
+          cargo test -- --test-threads=1
+
+  windows-vcpkg:
+    name: Windows (vcpkg)
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        shell: powershell
+        run: |
+          rustup update stable --no-self-update
+          rustup default stable
+
+      - name: Install LLVM
+        shell: powershell
+        run: choco install llvm --no-progress -y
+
+      - name: Set up vcpkg
+        shell: powershell
+        run: |
+          git clone https://github.com/microsoft/vcpkg.git C:\vcpkg
+          & C:\vcpkg\bootstrap-vcpkg.bat
+          & C:\vcpkg\vcpkg.exe install clamav:x64-windows openssl:x64-windows
+
+      - name: Build and test with vcpkg discovery
+        shell: powershell
+        env:
+          VCPKG_ROOT: C:\vcpkg
+          VCPKGRS_DYNAMIC: 1
+          LIBCLANG_PATH: C:\Program Files\LLVM\bin
+        run: |
+          $env:PATH = "C:\vcpkg\installed\x64-windows\bin;$env:PATH"
+          cargo test -- --test-threads=1
+
+  windows-manual:
+    name: Windows (manual)
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        shell: powershell
+        run: |
+          rustup update stable --no-self-update
+          rustup default stable
+
+      - name: Install LLVM
+        shell: powershell
+        run: choco install llvm --no-progress -y
+
+      - name: Install OpenSSL
+        shell: powershell
+        run: |
+          choco install openssl --no-progress -y -dv
+
+          $candidates = @(
+            "C:\Program Files\OpenSSL-Win64",
+            "C:\Program Files\OpenSSL",
+            "C:\tools\OpenSSL-Win64",
+            "C:\tools\OpenSSL"
+          )
+          $discovered = Get-ChildItem "C:\Program Files","C:\tools" -Directory -Filter "OpenSSL*" -ErrorAction SilentlyContinue |
+            Select-Object -ExpandProperty FullName
+          $opensslRoot = @($candidates + $discovered) |
+            Where-Object { Test-Path (Join-Path $_ "include") } |
+            Select-Object -First 1
+
+          if (-Not $opensslRoot) {
+            throw "OpenSSL include directory was not found after Chocolatey install"
+          }
+
+          $opensslInclude = Join-Path $opensslRoot "include"
+          $opensslBin = Join-Path $opensslRoot "bin"
+          Write-Host "OpenSSL root: $opensslRoot"
+          Write-Host "OpenSSL include: $opensslInclude"
+          Write-Host "OpenSSL bin: $opensslBin"
+
+          "OPENSSL_ROOT=$opensslRoot" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          "OPENSSL_INCLUDE=$opensslInclude" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          "OPENSSL_BIN=$opensslBin" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
+      - name: Download ClamAV release package
+        shell: powershell
+        run: |
+          $archive = "clamav-${env:CLAMAV_VERSION}.win.x64.zip"
+          $url = "https://github.com/Cisco-Talos/clamav/releases/download/clamav-${env:CLAMAV_VERSION}/$archive"
+          Invoke-WebRequest -Uri $url -OutFile $archive
+          Expand-Archive -Path $archive -DestinationPath C:\clamav -Force
+
+      - name: Build and test with manual library paths
+        shell: powershell
+        env:
+          CLAMAV_LIBRARY: C:\clamav\clamav-${{ env.CLAMAV_VERSION }}.win.x64\clamav.lib
+          CLAMAV_INCLUDE: C:\clamav\clamav-${{ env.CLAMAV_VERSION }}.win.x64\include
+          LIBCLANG_PATH: C:\Program Files\LLVM\bin
+        run: |
+          $env:PATH = "C:\clamav\clamav-${env:CLAMAV_VERSION}.win.x64;$env:OPENSSL_BIN;$env:PATH"
+          cargo test -- --test-threads=1

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,86 @@
+# Citizen Code of Conduct
+
+## 1. Purpose
+
+A primary goal of the ClamAV community is to be inclusive to the largest number of contributors, with the most varied and diverse backgrounds possible. As such, we are committed to providing a friendly, safe and welcoming environment for all, regardless of gender, sexual orientation, ability, ethnicity, socioeconomic status, and religion (or lack thereof).  
+
+This code of conduct outlines our expectations for all those who participate in our community, as well as the consequences for unacceptable behavior.
+
+We invite all those who participate in ClamAV to help us create safe and positive experiences for everyone.
+
+## 2. Open [Source/Culture/Tech] Citizenship
+
+A supplemental goal of this Code of Conduct is to increase open [source/culture/tech] citizenship by encouraging participants to recognize and strengthen the relationships between our actions and their effects on our community.
+
+Communities mirror the societies in which they exist and positive action is essential to counteract the many forms of inequality and abuses of power that exist in society.
+
+If you see someone who is making an extra effort to ensure our community is welcoming, friendly, and encourages all participants to contribute to the fullest extent, we want to know.
+
+## 3. Expected Behavior
+
+The following behaviors are expected and requested of all community members:
+
+ * Participate in an authentic and active way. In doing so, you contribute to the health and longevity of this community.
+ * Exercise consideration and respect in your speech and actions.
+ * Attempt collaboration before conflict.
+ * Refrain from demeaning, discriminatory, or harassing behavior and speech.
+ * Be mindful of your surroundings and of your fellow participants. Alert community leaders if you notice a dangerous situation, someone in distress, or violations of this Code of Conduct, even if they seem inconsequential.
+ * Remember that community event venues may be shared with members of the public; please be respectful to all patrons of these locations.
+
+## 4. Unacceptable Behavior
+
+The following behaviors are considered harassment and are unacceptable within our community:
+
+ * Violence, threats of violence or violent language directed against another person.
+ * Sexist, racist, homophobic, transphobic, ableist or otherwise discriminatory jokes and language.
+ * Posting or displaying sexually explicit or violent material.
+ * Posting or threatening to post other people's personally identifying information ("doxing").
+ * Personal insults, particularly those related to gender, sexual orientation, race, religion, or disability.
+ * Inappropriate photography or recording.
+ * Inappropriate physical contact. You should have someone's consent before touching them.
+ * Unwelcome sexual attention. This includes, sexualized comments or jokes as well as inappropriate touching or unwelcomed sexual advances.
+ * Deliberate intimidation, stalking or following (online or in person).
+ * Advocating for, or encouraging, any of the above behavior.
+ * Sustained disruption of community events, including talks and presentations.
+
+## 5. Consequences of Unacceptable Behavior
+
+Unacceptable behavior from any community member, including sponsors and those with decision-making authority, will not be tolerated.
+
+Anyone asked to stop unacceptable behavior is expected to comply immediately.
+
+If a community member engages in unacceptable behavior, the community organizers may take any action they deem appropriate, up to and including a temporary ban or permanent expulsion from the community without warning (and without refund in the case of a paid event).
+
+## 6. Reporting Guidelines
+
+If you are subject to or witness unacceptable behavior, or have any other concerns, please notify a community organizer as soon as possible. talos-external@cisco.com.
+
+Additionally, community organizers are available to help community members engage with local law enforcement or to otherwise help those experiencing unacceptable behavior feel safe. In the context of in-person events, organizers will also provide escorts as desired by the person experiencing distress.
+
+## 7. Addressing Grievances
+
+If you feel you have been falsely or unfairly accused of violating this Code of Conduct, you should notify Cisco-Talos with a concise description of your grievance. Your grievance will be handled in accordance with our existing governing policies. 
+
+## 8. Scope
+
+We expect all community participants (contributors, paid or otherwise; sponsors; and other guests) to abide by this Code of Conduct in all community venues--online and in-person--as well as in all one-on-one communications pertaining to community business.
+
+This code of conduct and its related procedures also applies to unacceptable behavior occurring outside the scope of community activities when such behavior has the potential to adversely affect the safety and well-being of community members.
+
+## 9. Contact info
+
+talos-external@cisco.com
+
+## 10. License and attribution
+
+The Citizen Code of Conduct is distributed by Stumptown Syndicate under a [Creative Commons Attribution-ShareAlike license](http://creativecommons.org/licenses/by-sa/3.0/). 
+
+Portions of text derived from the [Django Code of Conduct](https://www.djangoproject.com/conduct/) and the [Geek Feminism Anti-Harassment Policy](http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Policy).
+
+_Revision 2.3. Posted 6 March 2017._
+
+_Revision 2.2. Posted 4 February 2016._
+
+_Revision 2.1. Posted 23 June 2014._
+
+_Revision 2.0, adopted by the Stumptown Syndicate board on 10 January 2013. Posted 17 March 2013._

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 authors = [
     "Jonas Zaddach <jzaddach@cisco.com>",
     "Scott Hutton <schutton@cisco.com>",
+    "Valerie Snyder <valsnyde@cisco.com>",
 ]
 categories = ["external-ffi-bindings"]
 description = "ClamAV low level bindings for Rust"
@@ -10,7 +11,7 @@ homepage = "https://github.com/Cisco-Talos/clamav-sys/"
 license = "GPL-2.0"
 name = "clamav-sys"
 repository = "https://github.com/Cisco-Talos/clamav-sys/"
-version = "1.0.0"
+version = "1.5.0"
 
 [build-dependencies]
 bindgen = "0.64.0"

--- a/README.md
+++ b/README.md
@@ -1,60 +1,121 @@
 # clamav-sys
 
-clamav-sys is a minimal Rust interface around [libclamav](https://www.clamav.net).
-This package is not supposed to be used stand-alone, but only through its safe wrapper,
-clamav-rs.
-
+clamav-sys is a minimal Rust interface around [libclamav](https://github.com/Cisco-Talos/clamav).
+This package is not supposed to be used stand-alone, but only through a safe
+wrapper such as [clamav-async-rs](https://github.com/Cisco-Talos/clamav-async-rs).
 
 ## Building
 
-### Unix (anything but Windows)
-You should have the `clamav-dev` package of your distribution installed (ClamAV
-with headers). The headers and library should be picked up automatically via
-pkg-config.
+To compile and run `clamav-sys` directly or as a dependency of `clamav-async-rs`
+or a downstream application, you need:
+- `libclamav` and its development headers
+- OpenSSL development headers
 
-### Windows
-#### vcpkg
-The preferred way of handling dependencies is `vcpkg`.
-Point `$env:VCPKG_ROOT` to your `vcpkg` installation, and set
-`$env:VCPKGRS_DYNAMIC=1` to use dynamic linking (the default method of linking will
-likely not work, as `pdcurses` doesn't support the `x64-windows-static-md` triplet).
+### How discovery works
 
-See the [vcpkg crate's documentation](https://docs.rs/vcpkg) for more details. 
+`clamav-sys` looks for dependencies in this order:
 
-Gotchas:
-- Windows has its own version of a zlib dll that is incompatbile with vcpkg. If
-  you get a message such as "The procedure entry point gzdirect could not be
-  located in the dynamic link library", you'll want to make sure that the vcpkg
-  dynamic libraries in your PATH variable are preceding the Windows one.
-  ```
-  $env:PATH="$env:VCPKG_ROOT\installed\x64-windows\bin\;$env:PATH"
-  ```
-  This error is especially hard to diagnose in PowerShell, as the process will
-  just hang without any output. In cmd.exe you'll get the aforementioned dialog
-  box telling you about the error.
+1. If `CLAMAV_LIBRARY` and `CLAMAV_INCLUDE` are set, those paths are used.
+2. Otherwise, `pkg-config` is used on Unix, Linux, and macOS.
+3. Otherwise, `vcpkg` is used on Windows.
 
+If `OPENSSL_INCLUDE` is set, it is added to the header search path for bindgen.
 
-#### Manual
-If `vcpkg` is not available or cannot be found on your system, the build defaults
-to a manual specification of dependencies.
-You will need to define the following environment variables:
-- `CLAMAV_SOURCE`: Points to the directory where the ClamAV source is located.
-- `CLAMAV_BUILD`: Points to the ClamAV build directory.
-- `OPENSSL_INCLUDE`: Points to the include directory containing `openssl/ssl.h`.
+### Override variables
 
-### MacOS
-Install the development dependencies via `homebrew`:
+- `CLAMAV_LIBRARY`: Exact path to the ClamAV library file, such as
+  `libclamav.so`, `libclamav.dylib`, `libclamav.a`, or `clamav.lib`
+- `CLAMAV_INCLUDE`: One or more include directories containing `clamav.h`
+- `OPENSSL_INCLUDE`: Include directory containing `openssl/ssl.h`
+- `CLAMAV_STATIC`: On Windows, set to `1` to link `CLAMAV_LIBRARY` as a static
+  library when it points to a `.lib` file
+
+### Linux / Unix / macOS
+
+Install the ClamAV development package and OpenSSL headers. If they are
+installed in standard system locations, `pkg-config` is usually sufficient.
+
+If ClamAV is installed in a non-standard location, set `CLAMAV_LIBRARY` and
+`CLAMAV_INCLUDE`. Set `OPENSSL_INCLUDE` if OpenSSL headers are also outside the
+default include paths.
+
+Example in `sh`:
+```sh
+export CLAMAV_INCLUDE="$HOME/clams/1.5.2/include"
+export CLAMAV_LIBRARY="$HOME/clams/1.5.2/lib/libclamav.so"
+export OPENSSL_INCLUDE="$HOME/.mussels/install/host-static/include"
+export LD_LIBRARY_PATH="$HOME/clams/1.5.2/lib"
+cargo test
 ```
-brew install clamav openssl@1.1
+
+### macOS using Homebrew
+
+Install the dependencies:
+```sh
+brew install clamav openssl@3
 ```
 
-OpenSSL is not included in the environment to avoid shadowing Apple's one, so
-you need to tell the build script where it is located:
+Then set:
+```sh
+export OPENSSL_INCLUDE=/opt/homebrew/opt/openssl@3/include
 ```
-export OPENSSL_ROOT_DIR=/usr/local/Cellar/openssl@1.1/1.1.1i/
+
+### Windows using vcpkg
+
+If you use `vcpkg`, set `$env:VCPKG_ROOT` to your `vcpkg` installation and set
+`$env:VCPKGRS_DYNAMIC=1` to use dynamic linking. The default method often does
+not work because `pdcurses` does not support the `x64-windows-static-md`
+triplet.
+
+Install LLVM for `bindgen`, which requires `libclang` on Windows. Set
+`$env:LIBCLANG_PATH` to the directory containing `libclang.dll` or `clang.dll`.
+For example:
+```ps1
+$env:LIBCLANG_PATH = "C:\Program Files\LLVM\bin"
+```
+
+See the [vcpkg crate's documentation](https://docs.rs/vcpkg) for more details.
+
+> _Gotchas_:
+>
+> Windows has its own version of a zlib DLL that is incompatible with vcpkg.
+>
+> If building from PowerShell, the process may just hang without showing any
+> output.
+> If building from `cmd.exe`, a dialog box may pop up with this error message:
+> > "The procedure entry point gzdirect could not be located in the dynamic link
+> library"
+>
+> If this happens, you will want to make sure that the vcpkg dynamic libraries
+> in your `PATH` variable precede the Windows one.
+> ```ps1
+> $env:PATH = "$env:VCPKG_ROOT\installed\x64-windows\bin\;$env:PATH"
+> ```
+
+### Windows without vcpkg
+
+If not using vcpkg, you must use the override variables described above so that
+`cargo build` can find the required files.
+
+You must also install LLVM for `bindgen`, which requires `libclang` on
+Windows. Set `LIBCLANG_PATH` to the directory containing `libclang.dll` or
+`clang.dll`.
+
+If `CLAMAV_LIBRARY` points to a static `.lib`, also set
+`$env:CLAMAV_STATIC = "1"`.
+
+Example in PowerShell:
+```powershell
+$env:CLAMAV_LIBRARY = "$env:HOME\Downloads\clamav-1.5.2\clamav.lib"
+$env:CLAMAV_INCLUDE = "$env:HOME\Downloads\clamav-1.5.2\include"
+$env:CLAMAV_STATIC = "1"
+$env:OPENSSL_INCLUDE = "$env:HOME\Downloads\openssl\include"
+$env:LIBCLANG_PATH = "C:\Program Files\LLVM\bin"
+$env:PATH = "$env:HOME\Downloads\clamav-1.5.2;$env:PATH"
 ```
 
 ## Versioning
+
 The version number of `libclamav-sys` tracks ClamAV's version number. That is,
 you'll require at least ClamAV 1.0.0 to build `libclamav-sys` 1.0.0. As ClamAV
 usually doesn't do breaking API changes, you'll be able to use `libclamav-sys`

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,131 @@
+# ClamAV Security Policy
+
+## What constitutes a security issue / vulnerability?
+
+A security issue, or vulnerability, may be any bug that represents a threat to the security of the ClamAV users or any issue that a malicious person could use to cause a Denial of Service (DoS) attack on a network service running ClamAV, such as a mail filter or file upload scanner.
+
+This definition includes issues where untrusted user input such as scanning a file or loading a signature database`*` may cause a severe memory leak, cause a crash, cause an infinite loop, or provide any other means to impair or disable ClamAV.
+
+A vulnerability also includes all other traditional security vectors such as privilege escalation, remote code execution, information disclosure, etc.
+
+If you are unsure if your bug is a security issue, please report it as a security issue.
+
+> `*`Bytecode signatures are cross-platform executable plugins. ClamAV will not load bytecode signatures unless they are signed by Cisco-Talos or the user has intentionally enabled unsigned bytecode signatures. Issues that require disabling this security mechanism and then loading unsigned bytecode signatures or loading unsigned bytecode signatures with the ClamBC signature testing tool are not considered to be vulnerabilities.
+
+## Vulnerability reporting best practices.
+
+Do **not** discuss the issue in a public forum, the project mailing lists, in chat, or anywhere else.
+
+Do **not** create a ticket on GitHub Issues. GitHub Issues are public. Submitting any information there on how to exploit ClamAV puts the ClamAV community at risk. If you do report a vulnerability via GitHub issues, your issue will be promptly removed.
+
+Submit your report by email to psirt@cisco.com. Support requests submitted to Cisco PSIRT that are received via email are typically acknowledged within 48 hours. PSIRT will provide you with additional information on how to proceed. Cisco PSIRT will work with the ClamAV developers to confirm or reject the security vulnerability.
+
+If the report is rejected, PSIRT or the ClamAV developers will write to you to explain why.
+
+If the report is accepted, the ClamAV team will craft a fix and may request your help to verify that you find it satisfactory. Cisco will assign a CVE ID and will work with you to identify a disclosure date when the CVE summary will become public and when it will be safe to discuss in public.
+
+Please allow us at least 90 days (about 3 months) to craft a fix and publish a security patch version with the fix before you tell anyone else about it. This non-disclosure window is critical to the security of your fellow ClamAV users and to the security of other products using libclamav.
+
+## How do I submit my vulnerability report?
+
+Security issues should be reported to Cisco PSIRT. The recommended method is to submit in email form to psirt@cisco.com. For details, see: https://tools.cisco.com/security/center/resources/security_vulnerability_policy.html
+
+## What should I include in my vulnerability report?
+
+Follow the same best practices for reporting a regular bug, but do not submit it on GitHub Issues! Instead, craft an email with the detailed report and attached files and submit it to psirt@cisco.com.
+
+First, verify that the bug exists in the latest stable patch release. This may not be the latest release provided by your package manager.
+
+At a minimum include the following:
+
+- Include step-by-step instructions for how to reproduce the issue.
+
+- If the issue is triggered by scanning a specific file, either:
+
+  - Include the file in an encrypted zip along with the password.
+
+  - Include instructions for how to generate a file that can be used to reproduce the issue.
+
+- Describe your working environment:
+
+  - Use the `clamconf` tool provided with ClamAV to describe your configuration. The `clamconf` tool will include operating system name, version, architecture, configuration information, etc. If you cannot use `clamconf`, describe this information in your report by hand.
+
+  - If you found the bug using a fuzzer or some other system, describe the system and provide instructions for how we can reproduce the issue using the same or similar tools.
+
+- If you are reporting a crash when scanning a file with ClamScan or ClamD, include a backtrace. See below for instructions on how to obtain a crash backtrace.
+
+## How to obtain a crash backtrace.
+
+When reporting a crash, please send us the backtrace obtained from `gdb`, the GNU Project Debugger, if possible. Here are step by step instructions which will guide you through the process.
+
+### ClamScan
+
+Assuming you get something like this, then you can use these instructions to help collect a backtrace for the report:
+```bash
+clamscan --some-options some_file
+
+Segmentation fault
+```
+
+1. Have the kernel write a core dump.
+
+    For bourne-like shells (e.g. bash):
+    ```bash
+    ulimit -c unlimited
+    ```
+
+    For C-like shells (e.g. tcsh):
+
+    ```sh
+    limit coredumpsize unlimited
+    ```
+
+2. Now you should see the core dumped message:
+    ```bash
+    clamscan --some-options some_file
+
+    Segmentation fault (core dumped)
+    ```
+
+    Looking at your current working directory should reveal a file named core.
+
+3. Load the core file into gdb:
+    ```bash
+    gdb -core=core --args clamscan --some-options some_file
+    ```
+
+    You should now see the gdb prompt, as: `(gdb)`
+
+4. Just use the `bt` command at the prompt to make gdb print a full backtrace. Copy and paste it into the bug report. You can use the `q` command to leave gdb.
+
+### ClamD
+
+Follow these instructions to attach gdb to a running ClamD process so you can record a crash backtrace.
+
+1. Use `ps` to get the PID of ClamD (first number from the left):
+    ```bash
+    ps -aux (or ps -elf on SysV)
+
+    clamav 24897 0.0 1.9 38032 10068 ? S Jan13 0:00 clamd
+    ```
+
+2. Attach gdb to the running process. *Replace `24897` with the pid of ClamD and adjust the path of ClamD as needed*:
+    ```bash
+    gdb /usr/sbin/clamd 24897
+    ```
+
+    You should now get the gdb prompt, as: `(gdb)`
+
+3. If you want ClamD to continue running (i.e. until a segmentation fault occurs), issue the `continue gdb` command. Then perform the commands to trigger the crash (like scanning a specific file with ClamDScan).
+
+4. When the crash occurs, gdb will return to its prompt. As with the ClamScan instructions, use the `bt` command at the prompt to make gdb print a full backtrace. Copy and paste it into the bug report. You can use the `q` command to leave gdb.
+
+### GDB Commands
+
+- `bt` - will give a backtrace for the current thread.
+
+- `info threads` - will tell you how many threads there are.
+
+- `thread n` - will change to the specified thread, after which you can use the bt command again to get it’s backtrace.
+
+So, you basically want to use `info threads` to get the number of threads and their id numbers; and for each thread do `thread id_number`; then `bt`. Exit from gdb with the `quit` command. Reply `y` to the question about the program still running.

--- a/build.rs
+++ b/build.rs
@@ -84,6 +84,30 @@ const BINDGEN_FUNCTIONS: &[&str] = &[
     "cli_versig2",
     "cli_warnmsg",
     "lsig_increment_subsig_match",
+    "cl_cvdunpack_ex",
+    "cl_cvdverify_ex",
+    "cl_scandesc_ex",
+    "cl_scanmap_ex",
+    "cl_scanfile_ex",
+    "cl_fmap_set_name",
+    "cl_fmap_get_name",
+    "cl_fmap_set_path",
+    "cl_fmap_get_path",
+    "cl_fmap_get_fd",
+    "cl_fmap_get_size",
+    "cl_fmap_set_hash",
+    "cl_fmap_have_hash",
+    "cl_fmap_will_need_hash_later",
+    "cl_fmap_get_hash",
+    "cl_fmap_get_data",
+    "cl_scan_layer_get_fmap",
+    "cl_scan_layer_get_parent_layer",
+    "cl_scan_layer_get_type",
+    "cl_scan_layer_get_recursion_level",
+    "cl_scan_layer_get_object_id",
+    "cl_scan_layer_get_last_alert",
+    "cl_scan_layer_get_attributes",
+    "cl_engine_set_scan_callback",
 ];
 
 // Generate bindings for these types (structs, prototypes, etc.):
@@ -110,7 +134,108 @@ const BINDGEN_CONSTANTS: &[&str] = &[
     "LAYER_ATTRIBUTES_.*",
 ];
 
-const CLAMAV_LIBRARY_NAME: &str = "clamav";
+fn bindgen_with_include_paths(
+    mut bindings: bindgen::Builder,
+    include_paths: &[PathBuf],
+) -> bindgen::Builder {
+    for include_path in include_paths {
+        bindings = bindings
+            .clang_arg("-I")
+            .clang_arg(include_path.to_string_lossy().as_ref());
+    }
+
+    bindings
+}
+
+fn env_paths(name: &str) -> Option<Vec<PathBuf>> {
+    let value = env::var_os(name)?;
+    let paths = env::split_paths(&value).collect::<Vec<_>>();
+    Some(paths)
+}
+
+fn validate_manual_clamav_configuration() -> bool {
+    let has_library = env::var_os("CLAMAV_LIBRARY").is_some();
+    let has_include = env::var_os("CLAMAV_INCLUDE").is_some();
+
+    match (has_library, has_include) {
+        (false, false) => false,
+        (true, true) => true,
+        (true, false) => {
+            panic!("CLAMAV_INCLUDE must also be set when CLAMAV_LIBRARY is provided")
+        }
+        (false, true) => {
+            panic!("CLAMAV_LIBRARY must also be set when CLAMAV_INCLUDE is provided")
+        }
+    }
+}
+
+#[cfg(windows)]
+fn clamav_link_kind() -> &'static str {
+    match env::var("CLAMAV_STATIC").as_deref() {
+        Ok("1") => "static",
+        Ok(_) | Err(env::VarError::NotPresent) => "dylib",
+        Err(env::VarError::NotUnicode(_)) => {
+            panic!("CLAMAV_STATIC must be valid Unicode when set")
+        }
+    }
+}
+
+#[cfg(windows)]
+fn clamav_link_name(library_path: &std::path::Path) -> String {
+    let file_name = library_path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .expect("CLAMAV_LIBRARY must point to a valid library filename");
+
+    file_name
+        .strip_suffix(".lib")
+        .expect("CLAMAV_LIBRARY must point to a .lib file on Windows")
+        .to_string()
+}
+
+#[cfg(windows)]
+fn configure_manual_clamav_library() {
+    let library_path =
+        PathBuf::from(env::var_os("CLAMAV_LIBRARY").expect(
+            "CLAMAV_LIBRARY environment variable must be set when using manual ClamAV paths",
+        ));
+    let library_dir = library_path
+        .parent()
+        .expect("CLAMAV_LIBRARY must include a parent directory");
+    let library_kind = clamav_link_kind();
+    let library_name = clamav_link_name(&library_path);
+
+    println!(
+        "cargo:rustc-link-search=native={}",
+        library_dir.to_str().unwrap()
+    );
+    println!("cargo:rustc-link-lib={library_kind}={library_name}");
+}
+
+#[cfg(not(windows))]
+fn configure_manual_clamav_library() {
+    let library_path =
+        PathBuf::from(env::var_os("CLAMAV_LIBRARY").expect(
+            "CLAMAV_LIBRARY environment variable must be set when using manual ClamAV paths",
+        ));
+    let library_dir = library_path
+        .parent()
+        .expect("CLAMAV_LIBRARY must include a parent directory");
+
+    println!(
+        "cargo:rustc-link-search=native={}",
+        library_dir.to_str().unwrap()
+    );
+    println!("cargo:rustc-link-lib=dylib=clamav");
+}
+
+fn probe_from_env() -> Option<Vec<PathBuf>> {
+    configure_manual_clamav_library();
+    let include_paths = env_paths("CLAMAV_INCLUDE")
+        .expect("CLAMAV_INCLUDE environment variable must be set when using manual ClamAV paths");
+
+    Some(include_paths)
+}
 
 fn generate_bindings(customize_bindings: &dyn Fn(bindgen::Builder) -> bindgen::Builder) {
     let mut bindings = bindgen::Builder::default();
@@ -132,6 +257,9 @@ fn generate_bindings(customize_bindings: &dyn Fn(bindgen::Builder) -> bindgen::B
 
     bindings = bindings
         .header("wrapper.h")
+        // C doc comments can contain prose that rustdoc interprets as doctest code.
+        // Suppress generated comments so `cargo test` does not fail on invalid doctests.
+        .generate_comments(false)
         // Tell cargo to invalidate the built crate whenever any of the
         // included header files changed.
         .parse_callbacks(Box::new(bindgen::CargoCallbacks));
@@ -151,76 +279,50 @@ fn generate_bindings(customize_bindings: &dyn Fn(bindgen::Builder) -> bindgen::B
 }
 
 fn cargo_common() {
-    println!("cargo:rustc-link-lib=dylib={}", CLAMAV_LIBRARY_NAME);
-
     // Tell cargo to invalidate the built crate whenever the wrapper changes
     println!("cargo:rerun-if-changed=wrapper.h");
-}
-
-#[cfg(windows)]
-fn main() {
-    let include_paths = match vcpkg::find_package("clamav") {
-        Ok(pkg) => pkg.include_paths,
-        Err(err) => {
-            println!(
-                "cargo:warning=Either vcpkg is not installed, or an error occurred in vcpkg: {}",
-                err
-            );
-            let clamav_source = PathBuf::from(env::var("CLAMAV_SOURCE").expect("CLAMAV_SOURCE environment variable must be set and point to ClamAV's source directory"));
-            let clamav_build = PathBuf::from(env::var("CLAMAV_BUILD").expect("CLAMAV_BUILD environment variable must be set and point to ClamAV's build directory"));
-            let openssl_include = PathBuf::from(env::var("OPENSSL_INCLUDE").expect("OPENSSL_INCLUDE environment variable must be set and point to openssl's include directory"));
-            let profile = env::var("PROFILE").unwrap();
-
-            let library_path = match profile.as_str() {
-                "debug" => std::path::Path::new(&clamav_build).join("libclamav/Debug"),
-                "release" => std::path::Path::new(&clamav_build).join("libclamav/Release"),
-                _ => panic!("Unexpected build profile"),
-            };
-
-            println!(
-                "cargo:rustc-link-search=native={}",
-                library_path.to_str().unwrap()
-            );
-
-            vec![
-                clamav_source.join("libclamav"),
-                clamav_build,
-                openssl_include,
-            ]
-        }
-    };
-
-    cargo_common();
-    generate_bindings(&|x: bindgen::Builder| -> bindgen::Builder {
-        let mut x = x;
-        for include_path in &include_paths {
-            x = x.clang_arg("-I").clang_arg(include_path.to_str().unwrap());
-        }
-        x
-    });
+    println!("cargo:rerun-if-env-changed=CLAMAV_LIBRARY");
+    println!("cargo:rerun-if-env-changed=CLAMAV_INCLUDE");
+    println!("cargo:rerun-if-env-changed=CLAMAV_STATIC");
+    println!("cargo:rerun-if-env-changed=OPENSSL_INCLUDE");
 }
 
 #[cfg(unix)]
-fn main() {
-    let libclamav = pkg_config::Config::new()
-        .atleast_version("0.103")
+fn probe_system_include_paths() -> Vec<PathBuf> {
+    pkg_config::Config::new()
+        .atleast_version("1.5")
         .probe("libclamav")
-        .unwrap();
+        .unwrap()
+        .include_paths
+}
 
-    let mut include_paths = libclamav.include_paths;
+#[cfg(windows)]
+fn probe_system_include_paths() -> Vec<PathBuf> {
+    vcpkg::find_package("clamav")
+        .unwrap_or_else(|err| panic!("Failed to locate ClamAV with vcpkg: {err}"))
+        .include_paths
+}
 
-    if let Some(val) = std::env::var_os("OPENSSL_ROOT_DIR") {
-        let mut openssl_include_dir = PathBuf::from(val);
-        openssl_include_dir.push("include");
-        include_paths.push(openssl_include_dir);
+#[cfg(not(any(unix, windows)))]
+fn probe_system_include_paths() -> Vec<PathBuf> {
+    panic!("Unsupported platform")
+}
+
+fn main() {
+    let use_manual_clamav = validate_manual_clamav_configuration();
+    let mut include_paths = if use_manual_clamav {
+        probe_from_env().expect("manual ClamAV configuration should provide include paths")
+    } else {
+        probe_system_include_paths()
+    };
+
+    if let Some(openssl_include_paths) = env_paths("OPENSSL_INCLUDE") {
+        include_paths.extend(openssl_include_paths);
     }
 
     cargo_common();
+
     generate_bindings(&|x: bindgen::Builder| -> bindgen::Builder {
-        let mut x = x;
-        for include_path in &include_paths {
-            x = x.clang_arg("-I").clang_arg(include_path.to_str().unwrap());
-        }
-        x
+        bindgen_with_include_paths(x, &include_paths)
     });
 }

--- a/build.rs
+++ b/build.rs
@@ -17,6 +17,7 @@
 // MA 02110-1301, USA.
 
 use std::env;
+use std::fs;
 use std::path::PathBuf;
 
 // Generate bindings for these functions:
@@ -134,6 +135,8 @@ const BINDGEN_CONSTANTS: &[&str] = &[
     "LAYER_ATTRIBUTES_.*",
 ];
 
+const CLAMAV_VERSION_1_0_0: u32 = 0x010000;
+
 fn bindgen_with_include_paths(
     mut bindings: bindgen::Builder,
     include_paths: &[PathBuf],
@@ -151,6 +154,39 @@ fn env_paths(name: &str) -> Option<Vec<PathBuf>> {
     let value = env::var_os(name)?;
     let paths = env::split_paths(&value).collect::<Vec<_>>();
     Some(paths)
+}
+
+fn parse_preprocessor_integer(value: &str) -> Option<u32> {
+    let value = value.trim();
+    if let Some(hex) = value
+        .strip_prefix("0x")
+        .or_else(|| value.strip_prefix("0X"))
+    {
+        u32::from_str_radix(hex, 16).ok()
+    } else {
+        value.parse().ok()
+    }
+}
+
+fn detect_clamav_version_num(include_paths: &[PathBuf]) -> Option<u32> {
+    for include_path in include_paths {
+        for header_name in ["clamav.h", "clamav-version.h"] {
+            let header_path = include_path.join(header_name);
+            let Ok(header) = fs::read_to_string(&header_path) else {
+                continue;
+            };
+            println!("cargo:rerun-if-changed={}", header_path.display());
+
+            for line in header.lines() {
+                let line = line.trim();
+                if let Some(version) = line.strip_prefix("#define CLAMAV_VERSION_NUM") {
+                    return parse_preprocessor_integer(version);
+                }
+            }
+        }
+    }
+
+    None
 }
 
 fn validate_manual_clamav_configuration() -> bool {
@@ -285,6 +321,7 @@ fn cargo_common() {
     println!("cargo:rerun-if-env-changed=CLAMAV_INCLUDE");
     println!("cargo:rerun-if-env-changed=CLAMAV_STATIC");
     println!("cargo:rerun-if-env-changed=OPENSSL_INCLUDE");
+    println!("cargo:rustc-check-cfg=cfg(clamav_ge_1_0_0)");
 }
 
 #[cfg(unix)]
@@ -321,6 +358,12 @@ fn main() {
     }
 
     cargo_common();
+
+    let clamav_version_num = detect_clamav_version_num(&include_paths)
+        .expect("Unable to determine CLAMAV_VERSION_NUM from clamav.h");
+    if clamav_version_num >= CLAMAV_VERSION_1_0_0 {
+        println!("cargo:rustc-cfg=clamav_ge_1_0_0");
+    }
 
     generate_bindings(&|x: bindgen::Builder| -> bindgen::Builder {
         bindgen_with_include_paths(x, &include_paths)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,11 +88,11 @@ impl From<cl_error_t> for u32 {
 impl std::fmt::Display for cl_error_t {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         unsafe {
-            #[cfg(windows)]
-            let msg = CStr::from_ptr(cl_strerror(i32::from(*self)));
-
-            #[cfg(not(windows))]
+            #[cfg(clamav_ge_1_0_0)]
             let msg = CStr::from_ptr(cl_strerror(*self));
+
+            #[cfg(not(clamav_ge_1_0_0))]
+            let msg = CStr::from_ptr(cl_strerror(i32::from(*self)));
 
             f.write_str(msg.to_str().unwrap_or("<unknown ClamAV error>"))
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,64 +58,73 @@ impl PartialEq for cl_scan_options {
     }
 }
 
-/// We need this for Windows, MSVC will use an `i32` as underlying enum type instead of `u32` like
-/// gcc and clang.
 impl From<i32> for cl_error_t {
     fn from(val: i32) -> cl_error_t {
-        unsafe { cl_error_t(std::mem::transmute(val)) }
+        cl_error_t(val as _)
     }
 }
 
 impl From<u32> for cl_error_t {
     fn from(val: u32) -> cl_error_t {
-        cl_error_t(val)
+        cl_error_t(
+            val.try_into()
+                .expect("cl_error_t values must fit in the platform enum representation"),
+        )
     }
 }
 
 impl From<cl_error_t> for i32 {
     fn from(val: cl_error_t) -> i32 {
-        unsafe { std::mem::transmute(val.0) }
+        val.0 as i32
     }
 }
 
 impl From<cl_error_t> for u32 {
     fn from(val: cl_error_t) -> u32 {
-        val.0
+        val.0.try_into().expect("cl_error_t values must fit in u32")
     }
 }
 
 impl std::fmt::Display for cl_error_t {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         unsafe {
+            #[cfg(windows)]
+            let msg = CStr::from_ptr(cl_strerror(i32::from(*self)));
+
+            #[cfg(not(windows))]
             let msg = CStr::from_ptr(cl_strerror(*self));
+
             f.write_str(msg.to_str().unwrap_or("<unknown ClamAV error>"))
         }
     }
 }
 
-/// We need this for Windows, MSVC will use an `i32` as underlying enum type instead of `u32` like
-/// gcc and clang.
 impl From<i32> for cl_engine_field {
     fn from(val: i32) -> cl_engine_field {
-        unsafe { cl_engine_field(std::mem::transmute(val)) }
+        cl_engine_field(val as _)
     }
 }
 
 impl From<u32> for cl_engine_field {
     fn from(val: u32) -> cl_engine_field {
-        cl_engine_field(val)
+        cl_engine_field(
+            val.try_into()
+                .expect("cl_engine_field values must fit in the platform enum representation"),
+        )
     }
 }
 
 impl From<cl_engine_field> for i32 {
     fn from(val: cl_engine_field) -> i32 {
-        unsafe { std::mem::transmute(val.0) }
+        val.0 as i32
     }
 }
 
 impl From<cl_engine_field> for u32 {
     fn from(val: cl_engine_field) -> u32 {
         val.0
+            .try_into()
+            .expect("cl_engine_field values must fit in u32")
     }
 }
 
@@ -125,29 +134,30 @@ impl std::fmt::Display for cl_engine_field {
     }
 }
 
-/// We need this for Windows, MSVC will use an `i32` as underlying enum type instead of `u32` like
-/// gcc and clang.
 impl From<i32> for cl_msg {
     fn from(val: i32) -> cl_msg {
-        unsafe { cl_msg(std::mem::transmute(val)) }
+        cl_msg(val as _)
     }
 }
 
 impl From<u32> for cl_msg {
     fn from(val: u32) -> cl_msg {
-        cl_msg(val)
+        cl_msg(
+            val.try_into()
+                .expect("cl_msg values must fit in the platform enum representation"),
+        )
     }
 }
 
 impl From<cl_msg> for i32 {
     fn from(val: cl_msg) -> i32 {
-        unsafe { std::mem::transmute(val.0) }
+        val.0 as i32
     }
 }
 
 impl From<cl_msg> for u32 {
     fn from(val: cl_msg) -> u32 {
-        val.0
+        val.0.try_into().expect("cl_msg values must fit in u32")
     }
 }
 


### PR DESCRIPTION
Change build behavior to prioritize manually specified header
and library paths, when specified.

Change the environment variable names used when manually specifying
the header and library paths from:
- CLAMAV_SOURCE
- CLAMAV_BUILD
- OPENSSL_ROOT_DIR

To:
- CLAMAV_INCLUDE
- CLAMAV_LIBRARY
- OPENSSL_INCLUDE

Pkgconfig (unix) and Vcpkg (Windows) are now only used when the builder
does not provide explicit paths for the required files.
This is to prevent pkgconfig and vcpkg to be unintentionally used when
present on a system but a specific version of either dependency is
desired.

CLAM-2881